### PR TITLE
Add basic controller Role and RoleBinding and flag to enable

### DIFF
--- a/deploy/charts/external-secrets/templates/rbac.yaml
+++ b/deploy/charts/external-secrets/templates/rbac.yaml
@@ -1,4 +1,65 @@
 {{- if .Values.rbac.create -}}
+{{- if .Values.rbac.basic -}}
+apiVersion: rbac.authorization.k8s.io/v1
+{{- if and .Values.scopedNamespace .Values.scopedRBAC }}
+kind: Role
+{{- else }}
+kind: ClusterRole
+{{- end }}
+metadata:
+  name: {{ include "external-secrets.fullname" . }}-controller-basic
+  {{- if and .Values.scopedNamespace .Values.scopedRBAC }}
+  namespace: {{ .Values.scopedNamespace | quote }}
+  {{- end }}
+  labels:
+    {{- include "external-secrets.labels" . | nindent 4 }}
+rules:
+  - apiGroups:
+    - "external-secrets.io"
+    resources:
+    - "secretstores"
+    - "clustersecretstores"
+    - "externalsecrets"
+    - "clusterexternalsecrets"
+    verbs:
+    - "get"
+    - "list"
+    - "watch"
+  - apiGroups:
+    - ""
+    resources:
+    - "secrets"
+    verbs:
+    - "list"
+    - "watch"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+{{- if and .Values.scopedNamespace .Values.scopedRBAC }}
+kind: RoleBinding
+{{- else }}
+kind: ClusterRoleBinding
+{{- end }}
+metadata:
+  name: {{ include "external-secrets.fullname" . }}-controller-basic
+  {{- if and .Values.scopedNamespace .Values.scopedRBAC }}
+  namespace: {{ .Values.scopedNamespace | quote }}
+  {{- end }}
+  labels:
+    {{- include "external-secrets.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  {{- if and .Values.scopedNamespace .Values.scopedRBAC }}
+  kind: Role
+  {{- else }}
+  kind: ClusterRole
+  {{- end }}
+  name: {{ include "external-secrets.fullname" . }}-controller-basic
+subjects:
+  - name: {{ include "external-secrets.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace | quote }}
+    kind: ServiceAccount
+---
+{{- end }}
 apiVersion: rbac.authorization.k8s.io/v1
 {{- if and .Values.scopedNamespace .Values.scopedRBAC }}
 kind: Role
@@ -149,6 +210,7 @@ rules:
       - "patch"
       - "update"
 ---
+{{- if .Values.rbac.fullRB }}
 apiVersion: rbac.authorization.k8s.io/v1
 {{- if and .Values.scopedNamespace .Values.scopedRBAC }}
 kind: RoleBinding
@@ -175,6 +237,7 @@ subjects:
     namespace: {{ .Release.Namespace | quote }}
     kind: ServiceAccount
 ---
+{{- end }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/deploy/charts/external-secrets/values.yaml
+++ b/deploy/charts/external-secrets/values.yaml
@@ -60,6 +60,10 @@ serviceAccount:
 rbac:
   # -- Specifies whether role and rolebinding resources should be created.
   create: true
+  # -- Specifies whether basic role and rolebinding resources should be created.
+  basic: false
+  # -- Specifies whether full rolebinding resource should be created.
+  fullRB: true
 
 ## -- Extra environment variables to add to container.
 extraEnv: []


### PR DESCRIPTION
We do not want the service account for ExternalSecret controller to have full ClusterRoles by default,
because we would prefer each ExternalSecret customer to grant access to the service account in their applicative namespace one by one, creating a dedicated local RoleBinding
So we deduced a kind of basic/minimal ClusterRole for the ExternalSecret controller to not complain at startup
and created a ClusterRoleBinding associated
Chart template rbac.yaml file contains now the new basic ClusterRole and ClusterRoleBinding
and we added flags in values.yaml to enable/disable the basic configuration and/or the full one
the default values are set so that current situation remains